### PR TITLE
Detail observed behavior of AllowUnknownCertificateAuthority

### DIFF
--- a/xml/System.Security.Cryptography.X509Certificates/X509VerificationFlags.xml
+++ b/xml/System.Security.Cryptography.X509Certificates/X509VerificationFlags.xml
@@ -45,10 +45,10 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- These flags indicate the conditions under which chain verification should occur. For example, if an application does not require certificates time values in a chain to be valid, the IgnoreNotTimeValid flag can be used.  
-  
-   
-  
+ These flags indicate the conditions under which chain verification should occur. For example, if an application does not require certificates time values in a chain to be valid, the IgnoreNotTimeValid flag can be used.
+
+ Note that the behavior of certificate validation in .NET Core aims to standardize its behavior according to the underlying win32 implementation APIs (i.e. CertVerifyCertificateChainPolicy in wincrypt.h), even on other platforms. Therefore, AllowUnknownCertificateAuthority not only allows for an untrusted roots, but also permits partial chains on all platforms.
+ 
 ## Examples  
  The following example opens the current user's personal certificate store, allows the user to select a certificate, then writes certificate and certificate chain information to the console. The output depends on the certificate you select.  
   
@@ -131,7 +131,7 @@
       </ReturnValue>
       <MemberValue>16</MemberValue>
       <Docs>
-        <summary>Ignore that the chain cannot be verified due to an unknown certificate authority (CA).</summary>
+        <summary>Ignore that the chain cannot be verified due to an unknown certificate authority (CA), or a partial chain. Note that ignoring partial chain skips verification that the signing authority of the certificate under validation was actually signed by one of the known CAs, so this must be performed separately if desired.</summary>
       </Docs>
     </Member>
     <Member MemberName="IgnoreCertificateAuthorityRevocationUnknown">


### PR DESCRIPTION
AllowUnknownCertificateAuthority not only ignores untrusted roots, but also partial chains. This updates the documentation to reflect this behavior.

## Summary
See https://github.com/dotnet/runtime/issues/49615 for more details. AllowUnknownCertificateAuthority has the (presently) undocumented side effect of also ignoring the PartialChain verification status, which means that there is no validation that any of the root CAs added to the trust store were actually signing the certificate under verification.

Users unaware of this behavior could therefore be lulled into a false sense of safety when verification succeeds.

Fixes #49615.

